### PR TITLE
Add "HIDE_VALUES" diff level

### DIFF
--- a/command/format/plan.go
+++ b/command/format/plan.go
@@ -297,7 +297,7 @@ func formatPlanInstanceDiff(buf *bytes.Buffer, r *InstanceDiff, keyLen int, colo
 		)),
 	)
 
-	if diff.CurrentDiffLevel() == diff.AllLevel {
+	if diff.CurrentDiffLevel() != diff.RootLevel {
 		for _, attr := range r.Attributes {
 
 			v := attr.NewValue
@@ -307,6 +307,8 @@ func formatPlanInstanceDiff(buf *bytes.Buffer, r *InstanceDiff, keyLen int, colo
 				dispV = "<computed>"
 			case attr.Sensitive:
 				dispV = "<sensitive>"
+			case diff.CurrentDiffLevel() == diff.HideValuesLevel:
+				dispV = "<hidden>"
 			default:
 				dispV = fmt.Sprintf("%q", v)
 			}
@@ -325,6 +327,8 @@ func formatPlanInstanceDiff(buf *bytes.Buffer, r *InstanceDiff, keyLen int, colo
 				switch {
 				case attr.Sensitive:
 					dispU = "<sensitive>"
+				case diff.CurrentDiffLevel() == diff.HideValuesLevel:
+					dispU = "<hidden>"
 				default:
 					dispU = fmt.Sprintf("%q", u)
 				}

--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -108,13 +108,18 @@ func (h *UiHook) PreApply(
 	}
 	sort.Strings(keys)
 
-	if diff.CurrentDiffLevel() == diff.AllLevel {
+	if diff.CurrentDiffLevel() != diff.RootLevel {
 		// Go through and output each attribute
 		for _, attrK := range keys {
 			attrDiff, _ := d.GetAttribute(attrK)
 
 			v := attrDiff.New
 			u := attrDiff.Old
+			if diff.CurrentDiffLevel() == diff.HideValuesLevel {
+				u = "<hidden>"
+				v = "<hidden>"
+			}
+
 			if attrDiff.NewComputed {
 				v = "<computed>"
 			}

--- a/helper/diff/level.go
+++ b/helper/diff/level.go
@@ -13,12 +13,13 @@ const EnvDiff = "TF_DIFF"
 
 // These are the supported diff levels.
 const (
-	AllLevel  = DiffLevel("ALL")
-	RootLevel = DiffLevel("ROOT")
+	AllLevel        = DiffLevel("ALL")
+	HideValuesLevel = DiffLevel("HIDE_VALUES")
+	RootLevel       = DiffLevel("ROOT")
 )
 
 // ValidLevels is the list of supported diff levels.
-var ValidLevels = []DiffLevel{AllLevel, RootLevel}
+var ValidLevels = []DiffLevel{AllLevel, HideValuesLevel, RootLevel}
 
 var level DiffLevel
 


### PR DESCRIPTION
This PR adds a `HIDE_VALUES` diff level. When `TF_DIFF` is set to it, the attribute names will be shown in the diff, but their corresponding values will be shown as `<hidden>`.